### PR TITLE
Specify output filename

### DIFF
--- a/transcode-video.sh
+++ b/transcode-video.sh
@@ -73,6 +73,8 @@ Input options:
 Output options:
     --mkv           output Matroska format instead of MP4
     --m4v           output MP4 with \`.m4v\` extension instead of \`.mp4\`
+    --output        provide an alternative name for the output file (ignores 
+                        an extension setting, but does not change output format)
 
 Quality options:
     --big           raise default limits for both video and AC-3 audio bitrates
@@ -243,6 +245,7 @@ filter_options=''
 auto_deinterlace='yes'
 passthru_options=''
 debug=''
+output=''
 
 while [ "$1" ]; do
     case $1 in
@@ -266,6 +269,10 @@ while [ "$1" ]; do
             container_format='m4v'
             container_format_options='--large-file'
             ;;
+        --output)
+            output="$2"
+            shift
+            ;;        
         --preset|--veryfast|--faster|--fast|--slow|--slower|--veryslow)
 
             if [ "$1" == '--preset' ]; then
@@ -554,7 +561,9 @@ if ! $(echo "$media_info" | grep -q '^+ title '$media_title':$'); then
     exit 1
 fi
 
-readonly output="$(basename "$input" | sed 's/\.[0-9A-Za-z]\{1,\}$//').$container_format"
+if [ "$output" == '' ]; then
+    readonly output="$(basename "$input" | sed 's/\.[0-9A-Za-z]\{1,\}$//').$container_format"
+fi
 
 if [ -e "$output" ]; then
     die "output file already exists: $output"


### PR DESCRIPTION
Adds the ability to specify an output file name to the script.

When transcoding a TV series (from DVD) it is necessary to be able to specify the output format. For example the disc for The X-Files Season 1 Eps 1-4 is named "XFILES_DISC1" and when you want to transcode all episodes you have to manually rename the generated files. Being able to specify the output name solves this.

I have made the option such that it remains the current functionality, but allows to override the default name generation.
