### PR TITLE
Override audio settings for dolby surround 2.0 tracks

### DIFF
--- a/transcode-video.sh
+++ b/transcode-video.sh
@@ -108,6 +108,9 @@ Audio options:
     --ac3 BITRATE   set AC-3 audio bitrate to 384|448|640 kbps (default: 384)
     --pass-ac3 BITRATE
                     set passthru AC-3 audio <= 384|448|640 kbps (default: 448)
+    --force-encoder ENCODER
+                    forces the audio encoder to ENCODER, ignoring the auto-detected
+                        settings of this script
 
 Subtitle options:
     --burn TRACK    burn subtitle track (default: first forced track, if any)
@@ -228,6 +231,7 @@ allow_dts=''
 allow_surround='yes'
 ac3_bitrate='384'
 pass_ac3_bitrate='448'
+forced_encoder=''
 burned_subtitle_track=''
 auto_burn='yes'
 extra_subtitle_tracks=()
@@ -366,6 +370,10 @@ while [ "$1" ]; do
                     syntax_error "unsupported AC-3 audio passthru bitrate: $pass_ac3_bitrate"
                     ;;
             esac
+            ;;
+        --force-encoder)
+            forced_encoder="$2"
+            shift
             ;;
         --burn)
             burned_subtitle_track="$(printf '%.0f' "$2" 2>/dev/null)"
@@ -853,7 +861,11 @@ elif (($main_audio_track > 1)) || ((${#extra_audio_tracks[*]} > 0)); then
 fi
 
 if [ "$audio_track_list" ]; then
-    audio_options="--audio $audio_track_list --aencoder $audio_encoder_list"
+    if [ "$forced_encoder" == "" ]; then
+        audio_options="--audio $audio_track_list --aencoder $audio_encoder_list"
+    else
+        audio_options="--audio $audio_track_list --aencoder $forced_encoder"
+    fi
 
     if [ "$(echo "$audio_bitrate_list" | sed 's/,//g')" ]; then
         audio_options="$audio_options --ab $audio_bitrate_list"


### PR DESCRIPTION
When transcoding an older DVD of a famous TV series, the audio track is in AC3 2.0 dolby surround. When the script autodetects this audio, it transforms it into AAC stereo without any fallback for having the sound copied as is.

The option `--force-encoder ENCODER` will undo all the audio-detect magic that happens in the transcode video script and apply the `ENCODER` option instead.

For example, this allows me to call the script like this:

``` bash
transcode-video.sh --force-encoder copy:ac3 --single --mkv --add-subtitle 1 --title 1 --output The\ X-Files\ S01E01.mkv /Volumes/XFILES_DISC1
```

And get the original soundtrack of the DVD.
