### PR TITLE
Added fix_rotation and no_logs options

### DIFF
--- a/batch.sh
+++ b/batch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+usage() {
+	echo "batch.sh path_to_videos"
+	exit 0
+}
+
+input=$1
+script_path="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ -d "$input" ]];
+then
+	files="$(find "$input" -name "*.mov")"
+	# file="$(sed -n 1p <<< "$files")"
+	
+	echo "$files" | while read line; do
+			echo "$line"
+			
+	        # echo "./transcode-video.sh --720p --fix_rotation \"$line\""
+			output="$("$script_path"/transcode-video.sh --720p --fix_rotation --no_logs "$line" &)"
+			# output=$("$script_path"/exit.sh --720p --fix_rotation "$line")
+			
+			echo "$output"
+	        ((i++))
+	done
+
+
+	
+	# while [ "$file" ]; do
+	# 		sed '' 1d <<< "$files" || exit 1
+	# 		
+	# 		echo "transcode-video.sh --720p --fix_rotation \"$file\""
+	# 		# transcode-video.sh --720p --fix_rotation "$file"
+	# 		
+	# 
+	# 		file="$(sed -n 1p <<< "$files")"
+	# 	done
+else
+	echo "Error, no input"
+	usage
+fi


### PR DESCRIPTION
Not sure if you would be interested in this, but just in case I have added 2 options. No_logs just removes the log file after transcoding. Fix rotation fixes iPhone video rotation with ffmpeg before transcoding. I tried to do this using Handbrake but I couldn't. Handbrake seems to really want things to stay in landscape mode, so a portrait video that transcoded was looking to the left, when applied a 90º clockwise turn ended looking to the right (so it applied a 180º rotation). This way is not ideal as it's slower, but it works for me.