### PR TITLE
Simplify getting output file name without extension

### DIFF
--- a/convert-video.sh
+++ b/convert-video.sh
@@ -87,7 +87,7 @@ case $input_container in
         ;;
 esac
 
-readonly output="$(basename "$input" | sed 's/\.[^.]*$//').$container_format"
+readonly output="$(basename "${input%.*}").$container_format"
 
 if [ -e "$output" ]; then
     die "output file already exists: $output"


### PR DESCRIPTION
Changes the burden from `sed` to `bash` itself. Not sure why you took different approaches with these, though, was it intentional?