### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ But usually you need to scan the disk image first to find the correct title numb
 
     transcode-video.sh --title 0 "/path/to/Movie disc image directory/"
 
-All the titles in the disc image directory are then listed, along with other useful information like duration and format, so you can identify exactly which title you want. 
+All the titles in the disc image directory are then listed, along with other useful information like duration and format, so you can identify exactly which title you want.
 
 ## Guide
 

--- a/transcode-video.sh
+++ b/transcode-video.sh
@@ -156,7 +156,7 @@ Advanced options:
 Passthru options:
     --angle, --normalize-mix, --drc, --gain,
     --no-opencl, --optimize, --use-opencl, --use-hwd
-                    all passed through to \`HandBrakeCLI\` unchanged 
+                    all passed through to \`HandBrakeCLI\` unchanged
                         (refer to \`HandBrakeCLI --help\` for more information)
 
 Other options:
@@ -874,7 +874,7 @@ if [ "$audio_track_info" ]; then
                 audio_encoder_list="$audio_encoder_list,$stereo_audio_encoder,$surround_audio_encoder"
                 audio_bitrate_list="$audio_bitrate_list,,$surround_audio_bitrate"
             fi
- 
+
             if [ "$sanitized_name" != "$track_name" ]; then
 
                 if [ "$container_format" == 'mkv' ]; then


### PR DESCRIPTION
Damn that sneaky trailing whitespace, always introducing itself uninvited, and thank you `perl` for making it so easy to delete it.