### PR TITLE
Fix --add-all-subtitles when input contains no subtitles

### DIFF
--- a/transcode-video.sh
+++ b/transcode-video.sh
@@ -1224,6 +1224,9 @@ forced_subtitle_track_number=''
 track_id='1'
 
 for item in "${extra_subtitle_tracks[@]}"; do
+    if [ -z "$item" ]; then
+        continue
+    fi
     track_number="$(printf '%.0f' "$(echo "$item" | sed 's/^forced,//')" 2>/dev/null)"
 
     if (($track_number < 1)); then


### PR DESCRIPTION
If you pass --add-all-subtitles when transcoding a video that contains
no embedded subtitles, the below error is produced:
`transcode-video.sh: invalid additional subtitle track:`

Fix this by ignoring empty lines.

I'm not sure if this is the best place to have this check, so this may need revision.